### PR TITLE
fix plots; ggeffects::ggpredict() full.data arg is deprecated

### DIFF
--- a/12-glms.Rmd
+++ b/12-glms.Rmd
@@ -93,11 +93,11 @@ Let's fit a GLM that reflects these data.
 (m_gamma <- glm(y ~ x, family = 
     Gamma(link = "log"), data = d)) # exercise
 
-ggeffects::ggpredict(m_gamma, "x", full.data = TRUE) %>%
+ggeffects::ggpredict(m_gamma, "x") %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
-  geom_point(aes(y = observed))
+  geom_point(data = d, aes(x = x, y = y))  # plot simulated observations on top of predictions
 ```
 
 ## Poisson, log link
@@ -117,11 +117,11 @@ What are some examples of data sets that might resemble this?
 (m_poisson <- glm(y ~ x, family = 
     poisson(link = "log"), data = d)) # exercise
 
-ggeffects::ggpredict(m_poisson, "x", full.data = TRUE) %>%
+ggeffects::ggpredict(m_poisson, "x") %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
-  geom_point(aes(y = observed))
+  geom_point(data = d, aes(x = x, y = y))
 ```
 
 ## Negative binomial, log link
@@ -144,11 +144,11 @@ We have to use a special function to fit the negative binomial GLM in R:
 ```{r}
 (m_nb <- MASS::glm.nb(y ~ x, data = d))
 
-ggeffects::ggpredict(m_nb, "x", full.data = TRUE) %>%
+ggeffects::ggpredict(m_nb, "x") %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
-  geom_point(aes(y = observed))
+  geom_point(data = d, aes(x = x, y = y))
 ```
 
 ## Binomial, logit link
@@ -171,11 +171,11 @@ In what scenario might you see this kind of data?
 (m_bin <- glm(y ~ x, family = 
     binomial(link = "logit"), data = d)) # exercise
 
-g <- ggeffects::ggpredict(m_bin, "x", full.data = TRUE) %>%
+g <- ggeffects::ggpredict(m_bin, "x") %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
-  geom_point(aes(y = observed))
+  geom_point(data = d, aes(x = x, y = y))
 g
 
 coef(m_bin)

--- a/13-overdispersed-glms.Rmd
+++ b/13-overdispersed-glms.Rmd
@@ -72,11 +72,11 @@ Let's fit a GLM with a Poisson distribution and a log link even though we know t
 ```{r}
 (m_poisson <- glm(y ~ x, family = poisson(link = "log"), data = d))
 
-ggeffects::ggpredict(m_poisson, "x", full.data = TRUE) %>%
+ggeffects::ggpredict(m_poisson, "x") %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
-  geom_point(aes(y = observed))
+  geom_point(data = d, aes(x = x, y = y))
 ```
 
 If we look at the residuals, these should be constant with the predicted mean value. It can be hard to see these patterns in the residuals. There is not a lot to see here even though we know there is overdispersion.  


### PR DESCRIPTION
I get the following error when plotting the model predictions with simulated observed values

```
ggeffects::ggpredict(m_poisson, "x", full.data = TRUE) %>%
   ggplot(aes(x, predicted)) +
   geom_line(colour = "red") + 
   geom_ribbon(aes(ymin = conf.low, ymax = conf.high), alpha = .2) +
   geom_point(aes(y = observed))
```
```
Error in FUN(X[[i]], ...) : object 'observed' not found

```

- full.data is no longer an argument in ggeffects::ggpredict() and so 'observed' data no longer exists
- see https://github.com/strengejacke/ggeffects/issues/193

Here is a possible fix

